### PR TITLE
Add download dialog with url param

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,14 @@
     <button id="filebutton" class="cesium-button cesium-toolbar-button"><label for="fileupload"><span
           class="material-symbols-outlined">folder</span></label></button>
   </div>
+
+  <dialog>
+    <p>Download the GPX data from <a href="#" id="gpxLink" target="_blank">link</a> and drag and drop it into the window or use the file upload.</p>
+    <form method="dialog">
+      <button>OK</button>
+    </form>
+  </dialog>
+
   <div id="cesiumContainer" class="fullSize"></div>
 
   <script type="module" src="resources/main.js"></script>

--- a/resources/main.js
+++ b/resources/main.js
@@ -48,8 +48,6 @@ function loadData(gpx) {
   );
 }
 
-// "https://github.com/mbernasocchi/openmist/blob/398544228b8f700d0781cabae029a00a43a92b4f/resources/test/20240216.gpx"
-
 // check for gpx data link in url params and open download dialog
 const searchParams = new URL(window.location.href).searchParams;
 const gpxLink = searchParams.get("gpx")

--- a/resources/main.js
+++ b/resources/main.js
@@ -40,15 +40,33 @@ viewer.dataSources.dataSourceAdded.addEventListener(function (source) {
   colorize();
 });
 
+function loadData(gpx) {
+  viewer.dataSources.add(
+    Cesium.GpxDataSource.load(gpx, {
+      clampToGround: false,
+    })
+  );
+}
+
+// "https://github.com/mbernasocchi/openmist/blob/398544228b8f700d0781cabae029a00a43a92b4f/resources/test/20240216.gpx"
+
+// check for gpx data link in url params and open download dialog
+const searchParams = new URL(window.location.href).searchParams;
+const gpxLink = searchParams.get("gpx")
+if (gpxLink) {
+  // loadData(gpxLink) NOTE to load data immediately a server with necessary CORS header required or a backend
+  const linkEl = document.getElementById("gpxLink")
+  linkEl.href = gpxLink;
+  linkEl.textContent = gpxLink;
+  document.querySelector("dialog").showModal();
+}
+
+
 // function for loading local gpx
 function loadFile(event) {
   viewer.dataSources.removeAll();
   let tmppath = URL.createObjectURL(event.target.files[0]);
-  viewer.dataSources.add(
-    Cesium.GpxDataSource.load(tmppath, {
-      clampToGround: false,
-    })
-  );
+  loadData(tmppath)
 }
 
 // add colors to the track. TODO colorize by vertical speed
@@ -61,8 +79,6 @@ function colorize() {
     });
   });
 }
-
-
 
 // remove loading screen
 document.body.classList.remove("cesium-loading");

--- a/resources/main.js
+++ b/resources/main.js
@@ -52,7 +52,7 @@ function loadData(gpx) {
 const searchParams = new URL(window.location.href).searchParams;
 const gpxLink = searchParams.get("gpx")
 if (gpxLink) {
-  // loadData(gpxLink) NOTE to load data immediately a server with necessary CORS header required or a backend
+  // loadData(gpxLink) NOTE to load data immediately a server or proxy that adds the necessary CORS headers required or a backend
   const linkEl = document.getElementById("gpxLink")
   linkEl.href = gpxLink;
   linkEl.textContent = gpxLink;

--- a/resources/main.js
+++ b/resources/main.js
@@ -82,4 +82,3 @@ function colorize() {
 
 // remove loading screen
 document.body.classList.remove("cesium-loading");
-

--- a/resources/main.js
+++ b/resources/main.js
@@ -78,5 +78,8 @@ function colorize() {
   });
 }
 
+
+
 // remove loading screen
 document.body.classList.remove("cesium-loading");
+


### PR DESCRIPTION
Adresses #2  at least as a workaround 

When passed an url param `gpx` just opens a dialog on pageload to follow the link and download the data manually.

e.g.
https://openmist.berna.io/?gpx=https://github.com/mbernasocchi/openmist/blob/398544228b8f700d0781cabae029a00a43a92b4f/resources/test/20240216.gpx
